### PR TITLE
adding sshpass in external variables

### DIFF
--- a/ansible/external_vars.yaml
+++ b/ansible/external_vars.yaml
@@ -34,6 +34,7 @@ packages:
   - tree
   - wget
   - git
+  - sshpass
   - net-tools
   - bind-utils
   - iptables-services


### PR DESCRIPTION
sshpass is required for copy ssh key and making sshless connection.