### PR TITLE
Add logic for tag IS itself on 3.11 setups

### DIFF
--- a/amq/deploy-amq.sh
+++ b/amq/deploy-amq.sh
@@ -7,7 +7,7 @@
 ### variables
 name=broker-001
 nameSpace=amq
-storageClass=glusterfs-sc
+storageClass=glusterfs-file
 volumeCapacity=10Gi
 
 R='\033[1;31m'

--- a/jenkins/deploy-jenkins.sh
+++ b/jenkins/deploy-jenkins.sh
@@ -9,12 +9,17 @@ JENKINS_NAME=jenkins-001
 JJB_CM_NAME=jjb-configmap-001
 JJB_DC_NAME=jjb-001
 NAMESPACE=jenkins
-STORAGECLASS=glusterfs-sc
+STORAGECLASS=glusterfs-file
 VOLUMECAPACITY=10Gi
 MEMORYLIMIT=8192Mi
 
 ### change the registry for redhat.io to registry.access.redhat.com. it is necessary for the first time only, uncomment below line for the first time
 # oc tag registry.access.redhat.com/openshift3/jenkins-2-rhel7 jenkins:2 -n openshift; oc import-image jenkins:2 -n openshift &
+
+version=`oc version | awk '/openshift/ {print $2}' | cut -d . -f 1,2`
+if [ "$version" = "v3.11" ]; then
+    oc tag registry.access.redhat.com/openshift3/jenkins-2-rhel7 jenkins:2 -n openshift; oc import-image jenkins:2 -n openshift &
+fi
 
 function deploy_jenkins_and_jjb() {
     ### create namespace

--- a/mongodb/deploy-mongodb.sh
+++ b/mongodb/deploy-mongodb.sh
@@ -6,7 +6,7 @@
 ### variables
 name=mongodb-001
 nameSpace=mongodb
-storageClass=glusterfs-sc
+storageClass=glusterfs-file
 volumeCapacity=10Gi
 memoryLimit=8192Mi
 
@@ -19,6 +19,11 @@ oc create ns $nameSpace
 
 ### change the registry for redhat.io to registry.access.redhat.com. it is necessary for the first time only, uncomment below line for the first time
 # oc tag registry.access.redhat.com/rhscl/mongodb-32-rhel7 mongodb:3.2 -n openshift; oc import-image mongodb:3.2 -n openshift &
+
+version=`oc version | awk '/openshift/ {print $2}' | cut -d . -f 1,2`
+if [ "$version" = "v3.11" ]; then
+    oc tag registry.access.redhat.com/rhscl/mongodb-32-rhel7 mongodb:3.2 -n openshift; oc import-image mongodb:3.2 -n openshift &
+fi
 
 echo -e "\n${G}Creating a $name Secret, SVC, PVC, DC${N}"
 oc new-app mongodb.yaml -n $nameSpace -p DATABASE_SERVICE_NAME=$name -p STORAGE_CLASS=$storageClass -p VOLUME_CAPACITY=$volumeCapacity -p MEMORY_LIMIT=$memoryLimit

--- a/pgsql/deploy-pgsql.sh
+++ b/pgsql/deploy-pgsql.sh
@@ -7,7 +7,7 @@
 ### variables
 name=postgresql-001
 nameSpace=pgsql
-storageClass=glusterfs-sc
+storageClass=glusterfs-file
 volumeCapacity=10Gi
 memoryLimit=8192Mi
 
@@ -20,6 +20,11 @@ oc create ns $nameSpace
 
 ### change the registry for redhat.io to registry.access.redhat.com. it is necessary for the first time only, uncomment below line for the first time
 # oc tag registry.access.redhat.com/rhscl/postgresql-96-rhel7 postgresql:9.6 -n openshift; oc import-image postgresql:9.6 -n openshift &
+
+version=`oc version | awk '/openshift/ {print $2}' | cut -d . -f 1,2`
+if [ "$version" = "v3.11" ]; then
+    oc tag registry.access.redhat.com/rhscl/postgresql-96-rhel7 postgresql:9.6 -n openshift; oc import-image postgresql:9.6 -n openshift &
+fi
 
 echo -e "\n${G}Creating a $name Secret, SVC, PVC, DC${N}"
 oc new-app pgsql.yaml -n $nameSpace -p DATABASE_SERVICE_NAME=$name -p STORAGE_CLASS=$storageClass -p VOLUME_CAPACITY=$volumeCapacity -p MEMORY_LIMIT=$memoryLimit


### PR DESCRIPTION
With this feature we don't need to manually edit the deploy scripts for
tagging ImageStream with registry